### PR TITLE
Upgrade visual output of cleaner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "flate2",
  "glob",
  "image",
+ "indicatif",
  "itertools 0.14.0",
  "log",
  "pdfium-render",
@@ -861,6 +862,19 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -1974,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2113,16 @@ name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fastrand = "2.4.1"
 flate2 = "1.1.9"
 glob = "0.3.3"
 image = "0.25.10"
+indicatif = "0.18.4"
 itertools = "0.14.0"
 log = { version = "0.4.29", features = ["std"] }
 pdfium-render = {version = "0.9.1", features = ["image_025"]}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ alc-ng ./my-latex-project --keep-bib --clean-classes --latex-cmd pdflatex -f
 | `--verbose` | `-v` | `false` | Enable debug logging |
 | `--force` | `-f` | `false` | Continue on recoverable errors |
 | `--main-files` | `-m` | | Manually provide a list of main tex files as compile entrypoints.<br>The cleaner can usually infer main tex files automatically. |
-| `--keep-bib` | | `false` | Keep `.bib` files (by default only the generated `.bbl` is kept) |
+| `--keep-bib` | | `false` | Keep `.bib`, `.bst`, `.bbx`, `.dbx`, and `.cbx` files (by default only the generated `.bbl` is kept) |
 | `--clean-classes` | | `false` | Also clean `.sty` and `.cls` files |
 | `--latex-cmd` | | `latexmk` | LaTeX compiler to invoke (e.g. `latexmk`, `pdflatex`) |
 | `--latex-args` | | | Extra arguments passed to the LaTeX compiler |
@@ -162,7 +162,7 @@ ALC-NG combines several techniques to sanitize LaTeX projects while preserving t
 
 ### Bib file cleaning
 
-We currently do not support stripping unused entries from bibliographies. The default action is to only preserve the `.bbl` file that suffices to compile the document. You can use the `--keep-bib` flag to also preserve the original `.bib` file when cleaning.
+We currently do not support stripping unused entries from bibliographies. The default action is to only preserve the `.bbl` file that suffices to compile the document. You can use the `--keep-bib` flag to also preserve the original `.bib`, `.bst`, `.bbx`, `.dbx`, and `.cbx`, file when cleaning.
 
 We are planning to add support for this [later](#possible-enhancements).
 

--- a/src/cleaner/main.rs
+++ b/src/cleaner/main.rs
@@ -98,6 +98,7 @@ impl Config {
             strip_exif: self.strip_exif,
             skip_watermark: self.skip_watermark,
             user_provided_main_files: self.main_files.clone(),
+            verbose: self.verbose,
         }
     }
 
@@ -196,7 +197,10 @@ fn main() -> anyhow::Result<(), anyhow::Error> {
     if CONFIG.target_path.exists() {
         use dialoguer::Confirm;
         if Confirm::new()
-            .with_prompt("The target path already exists, do you want to override it?")
+            .with_prompt(format!(
+                "The target path ({}) already exists, do you want to override its contents?",
+                CONFIG.target_path.display()
+            ))
             .interact()?
             || !std::io::stdin().is_terminal()
         {
@@ -241,8 +245,19 @@ fn main() -> anyhow::Result<(), anyhow::Error> {
         }
 
         let mut same = true;
+        let mut has_fail = false;
 
-        for (f, res) in submission.compare()?.into_iter() {
+        let comparison = submission.compare()?;
+
+        for (f, res) in comparison.into_iter() {
+            let res = match res {
+                Some(res) => res,
+                None => {
+                    has_fail = true;
+                    continue;
+                }
+            };
+
             if res.is_empty() {
                 continue;
             }
@@ -260,23 +275,51 @@ fn main() -> anyhow::Result<(), anyhow::Error> {
             );
 
             let color = parse_hex_color(&CONFIG.diff_color)?;
-            for (page, (l, r)) in res {
+            for (page, imgs) in res.into_iter().sorted_by(|l, r| l.0.cmp(&r.0)) {
                 let path = CONFIG.target_path.join(format!("{}_{}.jpg", f, page));
-                image_diff(&l, &r, color)?.save_with_format(&path, image::ImageFormat::Jpeg)?;
 
-                info!(
-                    "Saved image diff for page {} of file {}: {}",
-                    page,
-                    f,
-                    path.display()
-                );
+                match imgs {
+                    (Some(l), Some(r)) => {
+                        image_diff(&l, &r, color)?
+                            .save_with_format(&path, image::ImageFormat::Jpeg)?;
+                        info!(
+                            "Saved image diff for page {} of file {}: {}",
+                            page,
+                            f,
+                            path.display()
+                        );
+                    }
+                    (Some(l), None) => {
+                        l.save_with_format(&path, image::ImageFormat::Jpeg)?;
+                        info!(
+                            "Saved image of original version for page {} of file {} (cleaned did not have this page): {}",
+                            page,
+                            f,
+                            path.display()
+                        );
+                    }
+                    (None, Some(r)) => {
+                        r.save_with_format(&path, image::ImageFormat::Jpeg)?;
+                        info!(
+                            "Saved image of cleaned version for page {} of file {} (original did not have this page): {}",
+                            page,
+                            f,
+                            path.display()
+                        );
+                    }
+                    _ => {}
+                }
             }
         }
 
-        if same {
+        if same && !has_fail {
             info!(
                 "The cleaned submission has no differences from the source. They are pixel-identical."
             );
+        }
+
+        if has_fail {
+            anyhow::bail!("At least one main file has problems.");
         }
     }
 

--- a/src/cleaner/main.rs
+++ b/src/cleaner/main.rs
@@ -4,7 +4,7 @@ use alc_ng::{
     helper::{ResultOkWithWarning, image_diff, parse_hex_color},
 };
 
-use clap::{Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use itertools::Itertools;
 use log::{LevelFilter, info, trace};
 use std::{
@@ -33,10 +33,8 @@ pub struct Config {
     #[arg(long)]
     pub latex_args: Vec<String>,
     /// If set, enable debug‑level logging.
-    #[arg(long, short, default_value_t = false)]
-    pub verbose: bool,
-    #[arg(long = "vv", default_value_t = false)]
-    pub debug: bool,
+    #[arg(short, long, action = ArgAction::Count)]
+    pub verbose: u8,
     /// Also compile the cleaned folder and compare the cleaned pdf output with the original pdfs.
     #[arg(long, short, default_value_t = false)]
     pub compare: bool,
@@ -98,7 +96,7 @@ impl Config {
             strip_exif: self.strip_exif,
             skip_watermark: self.skip_watermark,
             user_provided_main_files: self.main_files.clone(),
-            verbose: self.verbose,
+            verbose: self.verbose != 0,
         }
     }
 
@@ -154,10 +152,10 @@ pub fn ensure_requirements() {
 }
 
 fn main() -> anyhow::Result<(), anyhow::Error> {
-    let log_level = match (CONFIG.debug, CONFIG.verbose) {
-        (true, _) => log::LevelFilter::Trace,
-        (false, true) => log::LevelFilter::Debug,
-        (false, false) => log::LevelFilter::Info,
+    let log_level = match CONFIG.verbose {
+        0 => log::LevelFilter::Info,
+        1 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
     };
 
     env_logger::builder()
@@ -321,7 +319,7 @@ fn main() -> anyhow::Result<(), anyhow::Error> {
         }
     }
 
-    submission.stats().pretty_print(CONFIG.verbose);
+    submission.stats().pretty_print(CONFIG.verbose != 0);
 
     Ok(())
 }

--- a/src/cleaner/main.rs
+++ b/src/cleaner/main.rs
@@ -223,8 +223,6 @@ fn main() -> anyhow::Result<(), anyhow::Error> {
     )?;
     submission.run()?;
 
-    submission.stats().pretty_print(CONFIG.verbose);
-
     if CONFIG.compare {
         let compile_folder = TempDir::with_prefix("alc-ng_")?;
 
@@ -322,6 +320,8 @@ fn main() -> anyhow::Result<(), anyhow::Error> {
             anyhow::bail!("At least one main file has problems.");
         }
     }
+
+    submission.stats().pretty_print(CONFIG.verbose);
 
     Ok(())
 }

--- a/src/lib/arxiv/preflight.rs
+++ b/src/lib/arxiv/preflight.rs
@@ -58,7 +58,7 @@ impl TexFileIssue {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct MainProcessSpec {
     pub compiler: Option<CompilerSpec>,
     pub bibiliography: Option<BibProcessSpec>,
@@ -66,7 +66,7 @@ pub struct MainProcessSpec {
     pub fontmaps: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BibProcessSpec {
     pub processor: BibCompiler,
     pub pre_generator: bool,
@@ -81,7 +81,7 @@ impl BibProcessSpec {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IndexProcessSpec {
     processor: IndexCompiler,
     pre_generated: bool,
@@ -96,7 +96,7 @@ impl IndexProcessSpec {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompilerSpec {
     pub engine: EngineType,
     pub lang: LanguageType,
@@ -393,7 +393,7 @@ pub enum PostProcessType {
     DvipsPs2pdf,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum IndexCompiler {
     Unknown,
@@ -401,7 +401,7 @@ pub enum IndexCompiler {
     Mendex,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum BibCompiler {
     Unknown,

--- a/src/lib/arxiv/zzrm.rs
+++ b/src/lib/arxiv/zzrm.rs
@@ -121,18 +121,24 @@ impl Version {
 pub struct ZeroZeroReadMe {
     #[serde(default = "Version::get_v2")]
     version: Version,
-    pub process: MainProcessSpec,
-    #[serde(deserialize_with = "ZeroZeroReadMe::sources_array_to_map")]
+    pub process: Option<MainProcessSpec>,
+    #[serde(
+        deserialize_with = "ZeroZeroReadMe::sources_array_to_map",
+        default = "BTreeMap::new"
+    )]
     pub sources: BTreeMap<String, UserFile>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stamp: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     nohyperref: Option<bool>,
     #[serde(
+        default,
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_optional_u32_flexible"
     )]
     texlive_version: Option<u32>,
+    #[serde(default)]
+    pub path: PathBuf,
 }
 
 impl ZeroZeroReadMe {
@@ -150,18 +156,26 @@ impl ZeroZeroReadMe {
         )
         .map_err(|err| ZZRMException::UnsupportedFile(err.to_string()))?
         .filter_map(Result::ok)
-        .filter_map(|p| ZeroZeroReadMe::new_from_file(p).ok_with_warning())
         .collect();
 
         if candidates.len() > 1 {
-            return Err(ZZRMException::MultipleFiles(
-                "Multiple 00readme files found".into(),
-            ));
+            let candidate_paths = candidates
+                .iter()
+                .map(|p| p.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            return Err(ZZRMException::MultipleFiles(format!(
+                "Multiple 00readme files found: {}",
+                candidate_paths
+            )));
         }
 
-        candidates
-            .pop()
-            .ok_or(ZZRMException::FileNotFound("No 00readme file found".into()))
+        if let Some(candidate) = candidates.pop() {
+            ZeroZeroReadMe::new_from_file(candidate)
+        } else {
+            return Err(ZZRMException::FileNotFound("No 00readme file found".into()));
+        }
     }
 
     pub fn new_from_file<P>(file: P) -> Result<Self, ZZRMException>
@@ -182,7 +196,7 @@ impl ZeroZeroReadMe {
             ));
         }
 
-        Ok(match ext.as_str() {
+        let mut result = match ext.as_str() {
             // v1 extensions
             "txt" | "rst" | "readme" => Self::fetch_00readme_v1(file)?,
             // v2 extensions
@@ -193,7 +207,11 @@ impl ZeroZeroReadMe {
                     ext
                 )));
             }
-        })
+        };
+
+        result.path = file.to_path_buf();
+
+        Ok(result)
     }
 
     fn fetch_00readme_v1<P>(path: P) -> Result<Self, ZZRMException>
@@ -237,9 +255,16 @@ impl ZeroZeroReadMe {
                         "append" => userfile.usage = Some(FileUsage::Append),
                         "fontmap" => {
                             // global option – add to process.fontmaps
-                            zzrm.process
-                                .fontmaps
-                                .get_or_insert_with(|| vec![filename.to_string()]);
+                            if let Some(process) = &mut zzrm.process {
+                                process
+                                    .fontmaps
+                                    .get_or_insert_with(|| vec![filename.to_string()]);
+                            } else {
+                                zzrm.process = Some(MainProcessSpec {
+                                    fontmaps: Some(vec![filename.to_string()]),
+                                    ..Default::default()
+                                });
+                            }
                         }
                         _ => {
                             // unknown keyword
@@ -337,6 +362,8 @@ impl ZeroZeroReadMe {
     ) -> Result<Vec<(SourceFile, Command)>, ZZRMException> {
         let compiler = self
             .process
+            .clone()
+            .ok_or(ZZRMException::Parse("Missing process spec".into()))?
             .compiler
             .as_ref()
             .ok_or(ZZRMException::Parse("Missing compiler spec".into()))?

--- a/src/lib/cleaner/config.rs
+++ b/src/lib/cleaner/config.rs
@@ -27,6 +27,8 @@ pub struct CleanerConfig {
     pub skip_watermark: bool,
     /// Main files override
     pub user_provided_main_files: Option<Vec<PathBuf>>,
+    /// Print full LaTeX compiler output on failure.
+    pub verbose: bool,
 }
 
 impl Default for CleanerConfig {
@@ -44,6 +46,7 @@ impl Default for CleanerConfig {
             exiftool_args: Vec::new(),
             skip_watermark: false,
             user_provided_main_files: None,
+            verbose: false,
         }
     }
 }

--- a/src/lib/cleaner/submission.rs
+++ b/src/lib/cleaner/submission.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,
     fs::{File, FileTimes},
-    io::Write,
+    io::{IsTerminal as _, Write},
     ops::Not,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
@@ -28,7 +28,8 @@ use crate::{
 pub mod deletion_stats;
 pub mod parsed_file;
 
-type CompareResult = Result<HashMap<String, HashMap<usize, (DynamicImage, DynamicImage)>>>;
+type CompareResult =
+    Result<HashMap<String, Option<HashMap<usize, (Option<DynamicImage>, Option<DynamicImage>)>>>>;
 
 /// This struct contains all information needed to clean a LaTeX project.
 pub struct Submission {
@@ -381,10 +382,9 @@ impl Submission {
                             trace!("Compilation successful for {:?}", main_file.relative());
                         } else {
                             warn!(
-                                "Compilation failed for {:?} with status: {}:{:?}",
+                                "Compilation failed for {:?} with status: {}",
                                 main_file.relative(),
-                                output.status,
-                                String::from_utf8_lossy(&output.stderr)
+                                output.status
                             );
                         }
                     }
@@ -399,6 +399,85 @@ impl Submission {
                 (main_file, result)
             })
             .collect();
+
+        self.print_compile_failures();
+    }
+
+    /// Print stdout/stderr of failed compilations.
+    ///
+    /// If `verbose` is enabled, prints full output to stdout unconditionally.
+    /// Otherwise, asks the user via a y/n prompt whether to show the output.
+    fn print_compile_failures(&self) {
+        let has_failures = self
+            .latex_output
+            .values()
+            .any(|r| r.as_ref().is_ok_and(|o| o.status.code() != Some(0)));
+
+        if !has_failures {
+            return;
+        }
+
+        if self.cleaner_config.verbose {
+            self.print_failed_output();
+        } else {
+            use dialoguer::Confirm;
+            let should_show = if std::io::stdin().is_terminal() {
+                Confirm::new()
+                    .with_prompt("LaTeX compilation failed. Show full compiler output?")
+                    .default(false)
+                    .interact()
+                    .unwrap_or(false)
+            } else {
+                // Not a TTY (CI, piped input) — show output directly
+                true
+            };
+
+            if should_show {
+                self.print_failed_output();
+            }
+        }
+    }
+
+    /// Print the stdout/stderr of all failed compilations to stdout.
+    fn print_failed_output(&self) {
+        for (main_file, result) in &self.latex_output {
+            if let Ok(output) = result {
+                if !output.status.success() {
+                    let _ = writeln!(
+                        std::io::stdout(),
+                        "\n=== Compilation failed: {} ===",
+                        main_file.relative().display()
+                    );
+                    let _ = std::io::stdout().flush();
+
+                    if !output.stdout.is_empty() {
+                        let _ = writeln!(
+                            std::io::stdout(),
+                            "--- stdout ---\n{}\n---",
+                            String::from_utf8_lossy(&output.stdout)
+                        );
+                        let _ = std::io::stdout().flush();
+                    }
+
+                    if !output.stderr.is_empty() {
+                        let _ = writeln!(
+                            std::io::stdout(),
+                            "--- stderr ---\n{}\n---",
+                            String::from_utf8_lossy(&output.stderr)
+                        );
+                        let _ = std::io::stdout().flush();
+                    }
+                }
+            } else if let Err(e) = result {
+                let _ = writeln!(
+                    std::io::stdout(),
+                    "\n=== Failed to execute compilation for {}: {} ===",
+                    main_file.relative().display(),
+                    e
+                );
+                let _ = std::io::stdout().flush();
+            }
+        }
     }
 
     /// Detects BibTeX references that were not captured by the LaTeX recorder.
@@ -751,7 +830,7 @@ impl Submission {
             }
         }
 
-        for main_file in self.get_mains() {
+        let compile_results = self.get_mains().into_iter().map(|main_file| {
             use std::process::{Command, Stdio};
 
             info!(
@@ -784,39 +863,34 @@ impl Submission {
             cmd.stdout(Stdio::null());
             cmd.stderr(Stdio::null());
 
-            // Return a clone of the file reference along with its command.
-            if !cmd.status()?.success() {
-                warn!(
-                    "Failed to compile cleaned main file {}",
-                    main_file.relative().display()
-                );
-            };
-        }
+            (
+                main_file,
+                cmd.status().map(|s| s.success()).unwrap_or(false),
+            )
+        });
 
-        self
-            .get_mains()
-            .iter()
-            .map(|f| {
+        compile_results
+            .map(|(f, success)| {
+                if !success {
+                    warn!(
+                        "Failed to compile cleaned main file: {}",
+                        f.relative().display()
+                    );
+                    return Ok((f.relative().display().to_string(), None));
+                }
+
                 let original = f.full().with_extension("pdf");
                 let new_version = compile_folder
                     .path()
                     .join(f.relative().with_extension("pdf"));
 
                 if !original.exists() || !new_version.exists() {
-                    return Ok((f.relative().display().to_string(), HashMap::new()));
+                    return Ok((f.relative().display().to_string(), None));
                 }
+
                 let r = PixelPerfect::diff(&original, &new_version)?;
 
-                if !original.exists() {
-                    warn!("Original version did not compile successfully. Expected file {:?} to exist.", original)
-                }
-
-                if !new_version.exists() {
-                    warn!("Cleaned version did not compile successfully. Expected file {:?} to exist.", new_version)
-                }
-
-
-                Ok((f.relative().display().to_string(), r))
+                Ok((f.relative().display().to_string(), Some(r)))
             })
             .collect()
     }

--- a/src/lib/cleaner/submission.rs
+++ b/src/lib/cleaner/submission.rs
@@ -142,6 +142,16 @@ impl Submission {
             }
         };
 
+        if let Some(zzrm) = &zzrm {
+            info!(
+                "00Readme found at: {}",
+                zzrm.path
+                    .strip_prefix(&input_path)
+                    .unwrap_or(&zzrm.path)
+                    .display()
+            );
+        }
+
         // Ensure the output directory exists; create it if it does not.
         create_dir_all(&target_path).context("Failed to create output directory")?;
         trace!("Created/verified target directory: {:?}", target_path);
@@ -150,8 +160,6 @@ impl Submission {
         create_dir_all(&cache_dir).context("Faild to create cache directory")?;
         trace!("Created/verified cache directory: {:?}", cache_dir.path());
 
-        // Construct the `Submission` struct with all fields initialized.
-        trace!("Submission instance created successfully");
         Ok(Self {
             cleaner_config,
             input_path,

--- a/src/lib/cleaner/submission.rs
+++ b/src/lib/cleaner/submission.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     compare::{Comparer, PixelPerfect},
     exif_tool,
-    helper::{ResultOkWithWarning as _, SourceFile, find_mains},
+    helper::{ResultOkWithWarning as _, SourceFile, find_mains, find_referenced_bsts},
     progress::CompilationSpinner,
 };
 
@@ -54,6 +54,8 @@ pub struct Submission {
     latex_output: HashMap<SourceFile, std::io::Result<Output>>,
     /// List of bib files that were referenced in the log output during the compilation process of latexmk. A .bib file that is compiled by bibtex during latexmk is not listed in the recorder option of pdflatex.
     latexmk_referenced_bibs: HashSet<SourceFile>,
+    /// List of bst style files that were referenced in the log output during the compilation process of latexmk. A .bst file that is used by bibtex during latexmk is not listed in the recorder option of pdflatex.
+    latexmk_referenced_bsts: HashSet<SourceFile>,
     /// A set of possible latex files that contain text hinting at them being a main tex file.
     possible_main_files: HashSet<SourceFile>,
     /// The command used to compile the LaTeX document.
@@ -171,6 +173,7 @@ impl Submission {
             recorder_outputs: HashSet::new(),
             latex_output: HashMap::new(),
             latexmk_referenced_bibs: HashSet::new(),
+            latexmk_referenced_bsts: HashSet::new(),
             possible_main_files: HashSet::new(),
             latex_cmd: latex_cmd.to_string(),
             latex_parameters: latex_parameters.clone(),
@@ -509,9 +512,22 @@ impl Submission {
             .flat_map(|content| find_referenced_bibs(content.as_ref(), &self.cache_path)) // find bib files in the output
             .collect(); // gather into a HashSet
 
+        self.latexmk_referenced_bsts = self
+            .latex_output
+            .values()
+            .map(|o| o.as_ref()) // keep only successful outputs
+            .filter_map(Result::ok_with_warning)
+            .map(|o| String::from_utf8_lossy(&o.stdout[..])) // decode stdout as UTF-8 lossily
+            .flat_map(|content| find_referenced_bsts(content.as_ref(), &self.cache_path)) // find bib files in the output
+            .collect(); // gather into a HashSet
+
         trace!(
             "Found {} BibTeX file(s) referenced in latexmk output",
             self.latexmk_referenced_bibs.len()
+        );
+        trace!(
+            "Found {} BibTeX style file(s) referenced in latexmk output",
+            self.latexmk_referenced_bsts.len()
         );
     }
 
@@ -574,6 +590,7 @@ impl Submission {
         let all_used: HashSet<_> = self
             .recorder_inputs
             .union(&self.latexmk_referenced_bibs)
+            .chain(&self.latexmk_referenced_bsts)
             .collect();
         trace!("Total files marked as used: {}", all_used.len());
 

--- a/src/lib/cleaner/submission.rs
+++ b/src/lib/cleaner/submission.rs
@@ -23,6 +23,7 @@ use crate::{
     compare::{Comparer, PixelPerfect},
     exif_tool,
     helper::{ResultOkWithWarning as _, SourceFile, find_mains},
+    progress::CompilationSpinner,
 };
 
 pub mod deletion_stats;
@@ -364,17 +365,18 @@ impl Submission {
         // If no commands were created, log a warning to indicate a missing main file.
         if commands.is_empty() {
             warn!("No LaTeX commands to run. Either no main files found or 00readme is empty.");
+            return;
         }
 
-        // Execute each command, collecting the resulting Output into the `latex_output` map.
-        // The map key is the main file; the value is the Result of the command execution.
+        // Execute each command with a spinner, collecting the resulting Output
+        // into the `latex_output` map. The map key is the main file; the value
+        // is the Result of the command execution.
+        let mut spinner = CompilationSpinner::new(commands.len());
+
         self.latex_output = commands
             .into_iter()
             .map(|(main_file, mut cmd)| {
-                info!(
-                    "Compiling main file (this may take a while): {}",
-                    main_file.relative().display()
-                );
+                spinner.update(&main_file.relative().display().to_string());
                 let result = cmd.output();
                 match &result {
                     Ok(output) => {
@@ -400,6 +402,7 @@ impl Submission {
             })
             .collect();
 
+        spinner.finish();
         self.print_compile_failures();
     }
 
@@ -811,7 +814,9 @@ impl Submission {
     }
 
     pub fn compare(&self) -> CompareResult {
+        use std::process::{Command, Stdio};
         use walkdir::WalkDir;
+
         let compile_folder = TempDir::with_prefix("alc-ng_")?;
 
         let walker = WalkDir::new(self.target_path());
@@ -830,46 +835,52 @@ impl Submission {
             }
         }
 
-        let compile_results = self.get_mains().into_iter().map(|main_file| {
-            use std::process::{Command, Stdio};
+        let main_files: Vec<_> = self.get_mains().into_iter().collect();
 
-            info!(
-                "Compiling cleaned main file for comparison: {}",
-                main_file.relative().display()
-            );
+        // Compile each cleaned main file with a spinner
+        let mut spinner = CompilationSpinner::new(main_files.len());
+        let compile_results: Vec<_> = main_files
+            .into_iter()
+            .map(|main_file| {
+                spinner.update(&main_file.relative().display().to_string());
 
-            let mut cmd = Command::new(&self.latex_cmd);
+                let mut cmd = Command::new(&self.latex_cmd);
 
-            // Run in batch mode, record used files, and output PDF.
-            cmd.args([
-                "-cd",
-                "-f",
-                "-pdf",
-                "-interaction=nonstopmode",
-                "-synctex=1",
-                "-recorder",
-                "-bibtex-",
-            ]);
+                // Run in batch mode, record used files, and output PDF.
+                cmd.args([
+                    "-cd",
+                    "-f",
+                    "-pdf",
+                    "-interaction=nonstopmode",
+                    "-synctex=1",
+                    "-recorder",
+                    "-bibtex-",
+                ]);
 
-            // Append any additional LaTeX compiler arguments.
-            cmd.args(&self.latex_parameters);
+                // Append any additional LaTeX compiler arguments.
+                cmd.args(&self.latex_parameters);
 
-            // Target the main TeX file.
-            cmd.arg(main_file.relative());
+                // Target the main TeX file.
+                cmd.arg(main_file.relative());
 
-            // Execute the command in the cache directory.
-            cmd.current_dir(&compile_folder);
+                // Execute the command in the cache directory.
+                cmd.current_dir(&compile_folder);
 
-            cmd.stdout(Stdio::null());
-            cmd.stderr(Stdio::null());
+                cmd.stdout(Stdio::null());
+                cmd.stderr(Stdio::null());
 
-            (
-                main_file,
-                cmd.status().map(|s| s.success()).unwrap_or(false),
-            )
-        });
+                (
+                    main_file,
+                    cmd.status().map(|s| s.success()).unwrap_or(false),
+                )
+            })
+            .collect();
 
+        spinner.finish();
+
+        // Compare the compiled results
         compile_results
+            .into_iter()
             .map(|(f, success)| {
                 if !success {
                     warn!(
@@ -919,14 +930,17 @@ impl Submission {
                 .collect::<Result<HashSet<_>, _>>()?,
             None => find_mains(self.cache_path.path())?,
         };
-        info!(
-            "Found the following main TeX file(s):\n{}",
-            self.possible_main_files
-                .iter()
-                .map(|f| format!(" - {}", f.relative().to_string_lossy()))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
+
+        if !std::io::stderr().is_terminal() {
+            info!(
+                "Found the following main TeX file(s):\n{}",
+                self.possible_main_files
+                    .iter()
+                    .map(|f| format!(" - {}", f.relative().to_string_lossy()))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
 
         // Compile the identified main files using LaTeX.
         self.compile();

--- a/src/lib/cleaner/submission/parsed_file.rs
+++ b/src/lib/cleaner/submission/parsed_file.rs
@@ -1469,8 +1469,11 @@ impl<'a> ContentStripper<'a> {
             Some(b) => b,
             None if name == b"csname" => {
                 warn!(
-                    "If '{}' not defined. Assuming it is a LaTeX2e primitive conditional. Preserving if but cleaning both branches.",
-                    String::from_utf8_lossy(name)
+                    "If '{}' not defined at {}:{}:{}. Assuming it is a LaTeX2e primitive conditional. Preserving if but cleaning both branches.",
+                    String::from_utf8_lossy(name),
+                    self.filename,
+                    node.start_position().row + 1,
+                    node.start_position().column
                 );
                 new_content.extend_from_slice(&name_with_prefix);
 
@@ -1498,8 +1501,11 @@ impl<'a> ContentStripper<'a> {
             }
             None if IF_TEX_CONDITIONALS.contains(&name) => {
                 warn!(
-                    "If '{}' not defined. Assuming it is from the package 'iftex'. Preserving if but cleaning both branches.",
-                    String::from_utf8_lossy(name)
+                    "If '{}' not defined at {}:{}:{}. Assuming it is from the package 'iftex'. Preserving if but cleaning both branches.",
+                    String::from_utf8_lossy(name),
+                    self.filename,
+                    node.start_position().row + 1,
+                    node.start_position().column
                 );
                 new_content.extend_from_slice(&name_with_prefix);
 
@@ -1525,8 +1531,11 @@ impl<'a> ContentStripper<'a> {
                 new_content.extend_from_slice(node_content);
                 return exception(
                     anyhow!(
-                        "Custom if with name '{}' not defined",
-                        String::from_utf8_lossy(name)
+                        "Custom if with name '{}' not defined at {}:{}:{}",
+                        String::from_utf8_lossy(name),
+                        self.filename,
+                        node.start_position().row + 1,
+                        node.start_position().column
                     ),
                     Kept(new_content),
                     "tex-cleaner",

--- a/src/lib/cleaner/submission/parsed_file.rs
+++ b/src/lib/cleaner/submission/parsed_file.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsStr,
     fmt::Debug,
     fs::read,
     hash::Hash,
@@ -482,7 +483,16 @@ impl ParsedFile {
                     stats: Default::default(),
                 })
             }
-            Some(ext) if ext == "bib" => {
+            Some(ext)
+                if [
+                    OsStr::new("bib"),
+                    OsStr::new("bst"),
+                    OsStr::new("bbx"),
+                    OsStr::new("dbx"),
+                    OsStr::new("cbx"),
+                ]
+                .contains(&ext) =>
+            {
                 trace!("Detected BibTeX file: {}", path.display());
                 Self::Bib(BibFile {
                     cleaner_config,

--- a/src/lib/compare/comparer.rs
+++ b/src/lib/compare/comparer.rs
@@ -8,7 +8,7 @@ pub trait Comparer {
     fn diff<S: AsRef<Path>, T: AsRef<Path>>(
         left: S,
         right: T,
-    ) -> anyhow::Result<HashMap<usize, (DynamicImage, DynamicImage)>>;
+    ) -> anyhow::Result<HashMap<usize, (Option<DynamicImage>, Option<DynamicImage>)>>;
 
     fn are_equal<S: AsRef<Path>, T: AsRef<Path>>(left: S, right: T) -> bool;
 }

--- a/src/lib/compare/pixel_perfect.rs
+++ b/src/lib/compare/pixel_perfect.rs
@@ -100,7 +100,7 @@ impl Comparer for PixelPerfect {
     fn diff<S: AsRef<Path>, T: AsRef<Path>>(
         left: S,
         right: T,
-    ) -> anyhow::Result<HashMap<usize, (DynamicImage, DynamicImage)>> {
+    ) -> anyhow::Result<HashMap<usize, (Option<DynamicImage>, Option<DynamicImage>)>> {
         let left_images = Self::pdfimages(left).context("Failed to handle left images")?;
         let right_images = Self::pdfimages(right).context("Failed to handle right images")?;
 
@@ -111,11 +111,12 @@ impl Comparer for PixelPerfect {
             .filter_map(|(i, v)| match v {
                 itertools::EitherOrBoth::Both(l, r) => {
                     if l != r {
-                        return Some((i, (l, r)));
+                        return Some((i, (Some(l), Some(r))));
                     }
                     None
                 }
-                _ => None,
+                itertools::EitherOrBoth::Left(l) => Some((i, (Some(l), None))),
+                itertools::EitherOrBoth::Right(r) => Some((i, (None, Some(r)))),
             })
             .collect())
     }

--- a/src/lib/helper.rs
+++ b/src/lib/helper.rs
@@ -17,7 +17,7 @@ pub use find_mains::find_mains;
 pub use fls_parser::parse_fls;
 pub use image_diff::{image_diff, parse_hex_color};
 pub use is_newline::is_newline;
-pub use latexmk_bib_parser::find_referenced_bibs;
+pub use latexmk_bib_parser::{find_referenced_bibs, find_referenced_bsts};
 pub use log_ok::ResultOkWithWarning;
 pub use node_empty::is_empty;
 pub use source_file::GroupSourceFiles;

--- a/src/lib/helper/latexmk_bib_parser.rs
+++ b/src/lib/helper/latexmk_bib_parser.rs
@@ -9,6 +9,9 @@ static PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?im)^\s\s(.*)$"#).unwrap());
+static BST_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?im)The style file:\s*([\w./\\-]+\.(?:bst|bbx|cbx|dbx))"#).unwrap()
+});
 
 /// Finds referenced bibliography files in the given content.
 ///
@@ -41,5 +44,76 @@ pub fn find_referenced_bibs(content: &str, parent: impl AsRef<Path>) -> HashSet<
             })
             .collect(),
         None => HashSet::new(),
+    }
+}
+
+/// Finds referenced bibliography style files in the given content.
+///
+/// This function searches the `content` string for occurrences that match the
+/// `BST_PATTERN` regular expression, extracts each BST file path, and resolves
+/// them relative to the provided `parent` directory. The result is a set of
+/// `SourceFile`s representing each referenced style file.
+///
+/// # Arguments
+///
+/// * `content` - The text to search for style file references.
+/// * `parent` - The base directory used to resolve relative file paths.
+///
+/// # Returns
+///
+/// A `HashSet<SourceFile>` containing all referenced bibliography style files
+/// found in the content. If none are found, an empty set is returned.
+pub fn find_referenced_bsts(content: &str, parent: impl AsRef<Path>) -> HashSet<SourceFile> {
+    BST_PATTERN
+        .captures_iter(content)
+        .filter_map(|c| c.get(1).map(|v| v.as_str()))
+        .filter_map(|s| {
+            SourceFile::from_path(parent.as_ref().join(s), parent.as_ref()).ok_with_warning()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BTEX_LOG: &str = r#"-----------
+Running 'bibtex  "paper.aux"'
+------------
+This is BibTeX, Version 0.99e (TeX Live 2026)
+The top-level auxiliary file: paper.aux
+The style file: splncs04-etal.bst
+Database file #1: paper.bib
+Warning--empty booktitle in Albrechtetal2021Homomorphic
+Warning--empty booktitle in Anantharamanetal2026Evaluating
+Warning--empty booktitle in Rahmanietal2026Collaborative
+Warning--empty booktitle in Tempini2022PatientsLikeMe
+(There were 4 warnings)
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex':  Reasons for rerun
+Changed files or newly in use/created:
+  paper.aux
+  paper.out
+
+------------"#;
+
+    #[test]
+    fn test_bst_pattern_matches_style_file() {
+        let captures: Vec<_> = BST_PATTERN
+            .captures_iter(BTEX_LOG)
+            .filter_map(|c| c.get(1).map(|m| m.as_str()))
+            .collect();
+
+        assert_eq!(captures, vec!["splncs04-etal.bst"]);
+    }
+
+    #[test]
+    fn test_bst_pattern_no_match() {
+        let captures: Vec<_> = BST_PATTERN
+            .captures_iter("no style files here")
+            .filter_map(|c| c.get(1).map(|m| m.as_str()))
+            .collect();
+
+        assert!(captures.is_empty());
     }
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -4,3 +4,4 @@ pub mod compare;
 pub mod exif_tool;
 pub mod helper;
 pub mod parsing;
+pub mod progress;

--- a/src/lib/progress.rs
+++ b/src/lib/progress.rs
@@ -1,0 +1,58 @@
+use indicatif::{ProgressBar, ProgressStyle};
+use std::{io::IsTerminal, time::Duration};
+
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// A lightweight spinner shown while LaTeX files compile.
+///
+/// Prints to stderr so it doesn't interfere with log output on stdout.
+/// Automatically disabled when stderr is not a terminal.
+pub struct CompilationSpinner {
+    pb: Option<ProgressBar>,
+    current: usize,
+    total: usize,
+}
+
+impl CompilationSpinner {
+    /// Creates a new spinner for `total` files.
+    ///
+    /// If stderr is not a terminal, the spinner is a no-op.
+    pub fn new(total: usize) -> Self {
+        let pb = if std::io::stderr().is_terminal() && total > 0 {
+            let pb = ProgressBar::no_length();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .tick_strings(SPINNER_FRAMES)
+                    .template("{spinner} Compiling {msg}")
+                    .unwrap(),
+            );
+            pb.enable_steady_tick(Duration::from_millis(80));
+            Some(pb)
+        } else {
+            None
+        };
+
+        Self {
+            pb,
+            current: 0,
+            total,
+        }
+    }
+
+    /// Updates the spinner to show the current file being compiled.
+    pub fn update(&mut self, filename: &str) {
+        self.current += 1;
+        if let Some(pb) = &self.pb {
+            pb.set_message(format!("{} [{} / {}]", filename, self.current, self.total));
+        } else {
+            log::info!("Compiling main file (this may take a while): {filename}");
+        }
+    }
+
+    /// Finishes the spinner and clears it from the terminal.
+    pub fn finish(&mut self) {
+        if let Some(pb) = &self.pb {
+            pb.finish_with_message(format!("done ({} compiled)", self.total));
+        }
+    }
+}

--- a/src/lib/progress.rs
+++ b/src/lib/progress.rs
@@ -13,6 +13,12 @@ pub struct CompilationSpinner {
     total: usize,
 }
 
+impl Drop for CompilationSpinner {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
 impl CompilationSpinner {
     /// Creates a new spinner for `total` files.
     ///

--- a/tests/1806_01078v1.rs
+++ b/tests/1806_01078v1.rs
@@ -35,7 +35,7 @@ mod tests {
                 .compare()
                 .unwrap()
                 .into_iter()
-                .all(|(_, res)| res.is_empty())
+                .all(|(_, res)| res.is_some_and(|r| r.is_empty()))
         );
     }
 }

--- a/tests/2604_14468v2.rs
+++ b/tests/2604_14468v2.rs
@@ -35,7 +35,7 @@ mod tests {
                 .compare()
                 .unwrap()
                 .into_iter()
-                .all(|(_, res)| res.is_empty())
+                .all(|(_, res)| res.is_some_and(|r| r.is_empty()))
         );
     }
 }

--- a/tests/appendix.rs
+++ b/tests/appendix.rs
@@ -35,7 +35,7 @@ mod tests {
                 .compare()
                 .unwrap()
                 .into_iter()
-                .all(|(_, res)| res.is_empty())
+                .all(|(_, res)| res.is_some_and(|r| r.is_empty()))
         );
     }
 }


### PR DESCRIPTION
This PR adds following features:
- Add a loading spinner to latex compile steps
- Move print of deletion stats to end
- Add filenames and line numbers to missing if log outputs
- Improve parsing of 00readme
- Preserve bib style files when using --keep-bib

This PR can be tested using:
```bash
cargo install --git https://github.com/COMSYS/ALC-NG.git --branch progress-bar
```